### PR TITLE
connect.utils does not exist in newer Versions. I replaced md5 generation with js-md5

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Requirements
 - express & expresso - for tests
 - markdown - for documentation generation
 - cradle (= 0.1.0) - for CouchDB storage system
+- js-md5 (>= 0.4.1) - for creating hashes

--- a/lib/connect-cache.js
+++ b/lib/connect-cache.js
@@ -1,4 +1,4 @@
-var utils = require('connect').utils
+var md5 = require('js-md5')
   , http = require('http')
   , url = require('url');
 
@@ -62,8 +62,8 @@ exports = module.exports = function (options) {
       , loopback_host = tmp[0]
       , loopback_port = tmp.length > 1 ? tmp[1] : 80
       , key = !options.sensitive
-              ? utils.md5(url_hash.pathname.toLocaleLowerCase() + ("query" in url_hash ? '?' + url_hash.query : ''))
-              : utils.md5(req.url)
+              ? md5(url_hash.pathname.toLocaleLowerCase() + ("query" in url_hash ? '?' + url_hash.query : ''))
+              : md5(req.url)
       , content_key = 'c' + key
       , metas_key = 'm' + key
       , onCachedContentRetrieved = function (cached_metas, cached_content, write_stream) {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,22 @@
 {
   "name": "connect-cache",
   "description": "Caching system for Connect",
-  "keywords" : [ "connect", "cache", "caching system", "middleware" ],
+  "keywords": [
+    "connect",
+    "cache",
+    "caching system",
+    "middleware"
+  ],
   "version": "v0.2.1",
   "author": "Thomas Debarochez <thomas.barochez+npm@gmail.com>",
   "main": "./index.js",
-  "dependencies": { "connect": ">= 0.2.4" },
-  "engines": { "node": ">= 0.4.6" },
+  "dependencies": {
+    "connect": ">= 0.2.4",
+    "js-md5": "^0.4.1"
+  },
+  "engines": {
+    "node": ">= 0.4.6"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/tdebarochez/connect-cache.git"


### PR DESCRIPTION
Hi Thomas,

thanks for the middleware. It works great for our purposes. When using newer versions of `connect` e.g. `3.5` it doesn't work. `connect` removed `utils`. `connect-cache` uses them for the hash generation of the cache files. 

I replaced it with `js-md5` and it works according to my tests.

Regards
Stephan